### PR TITLE
Port over performance improvements from master

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ else:
 
 setup(
     name='freezegun',
-    version='0.3.7.affirm.4',
+    version='0.3.7.affirm.5',
     description='Let your Python tests travel through time',
     author='Steve Pulec',
     author_email='spulec@gmail',


### PR DESCRIPTION
from upstream:
- enable caching on module attributes. doing dir() every single call is extremely slow

local change:
- adding in_behave flag

Behave tests are tricky, I couldn't get tests to all be in harmony (esp. VCN tests). So i am leaving all freezegun usage in behave untouched.
With this change, affirm-users tests are able to finish in 13mins (down from 20+ on average).

Test build: https://jenkins-akkala.affirm-dev.com/job/all-the-things/job/targets/job/monolith/68371/